### PR TITLE
add prefix and postfix as optional term

### DIFF
--- a/contao/config/database.sql
+++ b/contao/config/database.sql
@@ -14,4 +14,6 @@
 CREATE TABLE `tl_metamodel_attribute` (
   `alias_fields` blob NULL,
   `force_alias` char(1) NOT NULL default ''
+  `alias_prefix` varchar(255) NOT NULL default ''
+  `alias_postfix` varchar(255) NOT NULL default ''
 ) ENGINE=MyISAM DEFAULT CHARSET=utf8;

--- a/contao/dca/tl_metamodel_attribute.php
+++ b/contao/dca/tl_metamodel_attribute.php
@@ -1,31 +1,53 @@
 <?php
 
 /**
- * The MetaModels extension allows the creation of multiple collections of custom items,
- * each with its own unique set of selectable attributes, with attribute extendability.
- * The Front-End modules allow you to build powerful listing and filtering of the
- * data in each collection.
+ * This file is part of MetaModels/attribute_alias.
  *
- * PHP version 5
+ * (c) 2012-2017 The MetaModels team.
  *
- * @package     MetaModels
- * @subpackage  AttributeAlias
- * @author      Christian Schiffler <c.schiffler@cyberspectrum.de>
- * @author      Andreas Isaak <info@andreas-isaak.de>
- * @author      Stefan Heimes <stefan_heimes@hotmail.com>
- * @copyright   The MetaModels team.
- * @license     LGPL.
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * This project is provided in good faith and hope to be usable by anyone.
+ *
+ * @package    MetaModels
+ * @subpackage AttributeAlias
+ * @author     Christian Schiffler <c.schiffler@cyberspectrum.de>
+ * @author     Andreas Isaak <info@andreas-isaak.de>
+ * @author     Stefan Heimes <stefan_heimes@hotmail.com>
+ * @author     Ingolf Steinhardt <info@e-spin.de>
+ * @copyright  2012-2017 The MetaModels team.
+ * @license    https://github.com/MetaModels/attribute_alias/blob/master/LICENSE LGPL-3.0
  * @filesource
- */
-
-/**
- * Table tl_metamodel_attribute
  */
 
 $GLOBALS['TL_DCA']['tl_metamodel_attribute']['metapalettes']['alias extends _simpleattribute_'] = array
 (
     '+advanced' => array('force_alias'),
-    '+display'  => array('alias_fields after description')
+    '+display'  => array('alias_prefix','alias_postfix','alias_fields after description')
+);
+
+$GLOBALS['TL_DCA']['tl_metamodel_attribute']['fields']['alias_prefix'] = array
+(
+    'label'     => &$GLOBALS['TL_LANG']['tl_metamodel_attribute']['alias_prefix'],
+    'exclude'   => true,
+    'inputType' => 'text',
+    'eval'      => array
+    (
+        'rgxp'     => 'alpha',    
+        'tl_class' => 'clr w50'
+    ),
+);
+
+$GLOBALS['TL_DCA']['tl_metamodel_attribute']['fields']['alias_postfix'] = array
+(
+    'label'     => &$GLOBALS['TL_LANG']['tl_metamodel_attribute']['alias_postfix'],
+    'exclude'   => true,
+    'inputType' => 'text',
+    'eval'      => array
+    (
+        'tl_class' => 'w50'
+    ),
 );
 
 $GLOBALS['TL_DCA']['tl_metamodel_attribute']['fields']['alias_fields'] = array
@@ -35,6 +57,7 @@ $GLOBALS['TL_DCA']['tl_metamodel_attribute']['fields']['alias_fields'] = array
     'inputType' => 'multiColumnWizard',
     'eval'      => array
     (
+        'tl_class' => 'clr',
         'columnFields' => array
         (
             'field_attribute' => array

--- a/contao/languages/en/tl_metamodel_attribute.php
+++ b/contao/languages/en/tl_metamodel_attribute.php
@@ -3,7 +3,7 @@
 /**
  * This file is part of MetaModels/attribute_alias.
  *
- * (c) 2012-2016 The MetaModels team.
+ * (c) 2012-2017 The MetaModels team.
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
@@ -15,7 +15,8 @@
  * @author     Christian Schiffler <c.schiffler@cyberspectrum.de>
  * @author     Andreas Isaak <info@andreas-isaak.de>
  * @author     Stefan Heimes <stefan_heimes@hotmail.com>
- * @copyright  2012-2016 The MetaModels team.
+ * @author     Ingolf Steinhardt <info@e-spin.de>
+ * @copyright  2012-2017 The MetaModels team.
  * @license    https://github.com/MetaModels/attribute_alias/blob/master/LICENSE LGPL-3.0
  * @filesource
  */
@@ -24,6 +25,12 @@
  * Fields
  */
 $GLOBALS['TL_LANG']['tl_metamodel_attribute']['typeOptions']['alias'] = 'Alias';
+$GLOBALS['TL_LANG']['tl_metamodel_attribute']['alias_prefix'][0]      = 'Alias prefix';
+$GLOBALS['TL_LANG']['tl_metamodel_attribute']['alias_prefix'][1]      =
+    'Optionally add a prefix term.';
+$GLOBALS['TL_LANG']['tl_metamodel_attribute']['alias_postfix'][0]     = 'Alias postfix';
+$GLOBALS['TL_LANG']['tl_metamodel_attribute']['alias_postfix'][1]     =
+    'Optionally add a postfix term.';
 $GLOBALS['TL_LANG']['tl_metamodel_attribute']['alias_fields'][0]      = 'Alias fields';
 $GLOBALS['TL_LANG']['tl_metamodel_attribute']['alias_fields'][1]      =
     'Please select one or more attributes to combine a alias.';

--- a/src/MetaModels/Attribute/Alias/Alias.php
+++ b/src/MetaModels/Attribute/Alias/Alias.php
@@ -29,11 +29,7 @@ use ContaoCommunityAlliance\Contao\Bindings\Events\Controller\ReplaceInsertTagsE
 use MetaModels\Attribute\BaseSimple;
 
 /**
- * This is the MetaModelAttribute class for handling text fields.
- *
- * @package    MetaModels
- * @subpackage AttributeAlias
- * @author     Christian Schiffler <c.schiffler@cyberspectrum.de>
+ * This is the MetaModelAttribute class for handling the alias field.
  */
 class Alias extends BaseSimple
 {
@@ -60,7 +56,9 @@ class Alias extends BaseSimple
                 'alwaysSave',
                 'filterable',
                 'searchable',
-                'sortable'
+                'sortable',
+                'alias_prefix',
+                'alias_postfix'
             )
         );
     }
@@ -103,9 +101,18 @@ class Alias extends BaseSimple
         }
 
         $arrAlias = [];
+
+        if ($this->get('alias_prefix')) {
+            $arrAlias[] = $this->get('alias_prefix');
+        }
+
         foreach (deserialize($this->get('alias_fields')) as $strAttribute) {
             $arrValues  = $objItem->parseAttribute($strAttribute['field_attribute'], 'text', null);
             $arrAlias[] = $arrValues['text'];
+        }
+
+        if ($this->get('alias_postfix')) {
+            $arrAlias[] = $this->get('alias_postfix');
         }
 
         $dispatcher   = $this->getMetaModel()->getServiceContainer()->getEventDispatcher();


### PR DESCRIPTION
add two fields as prefix and postfix to generate the alias - you can prohibit to generate the default `id` prefix from Contao if you have numbers at alias e.g. year or birthday or a product number